### PR TITLE
Refactored singleWeek fn

### DIFF
--- a/backend/server/plannerCtrl.js
+++ b/backend/server/plannerCtrl.js
@@ -44,53 +44,23 @@ export const plannerFns = {
 
     const { weekId } = req.body;
 
-    const week = await Week.findByPk(weekId, {
-      separate: true,
-      include: [
-        {
-          model: User,
-          attributes: [],
-          where: {
-            userId,
-          },
-        },
-        {
-          model: WeekMeal,
-          separate: true,
-          include: [
-            {
-              model: Recipe,
-              include: [
-                {
-                  model: RecipeIngredient,
-                  include: [Ingredient, MeasurementQuantity, MeasurementUnit],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    });
+    try {
+      const resObj = await getUserWeeks(userId, weekId);
 
-    if (!week?.weekMeals) {
+      if (resObj.success) {
+        resObj.message = `Successfully got week data by weekId`;
+      }
+
+      return res.send(resObj);
+    } catch (error) {
+      console.log();
+      console.error(error);
+      console.log();
+
       return res.send({
-        message: `This week does not belong to user`,
-        success: false,
+        message: `Error when trying to get week data by weekId`,
       });
     }
-
-    if (week.weekMeals.length === 0) {
-      return res.send({
-        message: `Week contains no recipes`,
-        success: false,
-      });
-    }
-
-    return res.send({
-      message: `Successfuly got week data by weekId`,
-      success: true,
-      week,
-    });
   },
 
   addUserWeek: async (req, res) => {

--- a/functions/getUserWeeks.js
+++ b/functions/getUserWeeks.js
@@ -10,7 +10,7 @@ import {
   WeekMeal,
 } from "../backend/db/model.js";
 
-const getUserWeeks = async (userId) => {
+const getUserWeeks = async (userId, weekId) => {
   const userWeeks = await User.findByPk(userId, {
     attributes: ["userId"],
     separate: true,
@@ -18,6 +18,7 @@ const getUserWeeks = async (userId) => {
       {
         model: Week,
         separate: true,
+        where: weekId ? { weekId } : {},
         include: [
           {
             model: WeekMeal,


### PR DESCRIPTION
The `single-week` endpoint will now respond with the same structure of data as the `user-weeks` end point. This was done to allow the grocery list generation function to have consistent input data to work from.