### PR TITLE
Fixed truncating key names

### DIFF
--- a/backend/server/recipeCtrl.js
+++ b/backend/server/recipeCtrl.js
@@ -304,9 +304,11 @@ export const recipeFns = {
 
     const savedRecipes = await User.findByPk(userId, {
       attributes: ["userId"],
+      separate: true,
       include: [
         {
           model: UserRecipe,
+          separate: true,
           include: [
             {
               model: Recipe,


### PR DESCRIPTION
Response issue with data from user-recipes endpoint where query results had truncated key names.